### PR TITLE
Add crossrefs to Salt's conf_(minion|master)

### DIFF
--- a/project/docs/_ext/saltdomain.py
+++ b/project/docs/_ext/saltdomain.py
@@ -1,0 +1,18 @@
+"""
+Copied/distilled from Salt doc/_ext/saltdomain.py in order to be able
+to use Salt's custom doc refs.
+"""
+
+
+def setup(app):
+    app.add_crossref_type(
+        directivename="conf_master",
+        rolename="conf_master",
+        indextemplate="pair: %s; conf/master",
+    )
+    app.add_crossref_type(
+        directivename="conf_minion",
+        rolename="conf_minion",
+        indextemplate="pair: %s; conf/minion",
+    )
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/project/docs/conf.py.j2
+++ b/project/docs/conf.py.j2
@@ -94,6 +94,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx_copybutton",
     "sphinxcontrib.spelling",
+    "saltdomain",
     "sphinxcontrib.towncrier.ext",
     "myst_parser",
     "sphinx_inline_tabs",


### PR DESCRIPTION
Allows to cross-reference Salt configuration options. This is taken from `saltext-vault` because I thought it would be useful more broadly.