### PR TITLE
Add option for test container support

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -196,6 +196,11 @@ ssh_fixtures:
   default: '{{ "wrapper" in loaders }}'
   when: '{{ "wrapper" not in loaders }}'
 
+test_containers:
+  type: bool
+  help: Add support for test containers in functional/integration tests
+  default: false
+
 workflows:
   type: str
   help: Choose which workflow style to create

--- a/project/noxfile.py.j2
+++ b/project/noxfile.py.j2
@@ -145,6 +145,19 @@ def tests(session):
         "COVERAGE_PROCESS_START": str(REPO_ROOT / ".coveragerc"),
     }
 
+{%- if container_tests %}
+
+    # Support running functional/integration tests under Podman rootless.
+    # The user must have enabled the listening socket via systemctl --user start podman.socket
+    if not CI_RUN and sys.platform.startswith("linux"):
+        uid = os.getuid()
+        if uid != 0:
+            runtime_dir = Path(os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{uid}"))
+            podman_sock = runtime_dir / "podman" / "podman.sock"
+            if podman_sock.exists():
+                env["DOCKER_HOST"] = f"unix:{podman_sock}"
+{%- endif %}
+
     session.run("coverage", "erase")
     args = [
         "--rootdir",

--- a/project/pyproject.toml.j2
+++ b/project/pyproject.toml.j2
@@ -80,7 +80,12 @@ lint = [
 ]
 tests = [
     "pytest>=7.2.0",
+{%- if test_containers %}
+    "pytest-salt-factories>=1.0.0; sys_platform == 'win32'",
+    "pytest-salt-factories[docker]>=1.0.0; sys_platform != 'win32'",
+{%- else %}
     "pytest-salt-factories>=1.0.0",
+{%- endif %}
 ]
 
 [project.entry-points."salt.loader"]


### PR DESCRIPTION
Taken from `saltext-vault`, this should be useful for other extensions as well.

Based on https://github.com/salt-extensions/salt-extension-copier/pull/6.