### PR TITLE
Switch from deprecated set-output to environment file

### DIFF
--- a/project/.github/workflows/{% if workflows == 'basic' %}test.yml{% endif %}.j2
+++ b/project/.github/workflows/{% if workflows == 'basic' %}test.yml{% endif %}.j2
@@ -114,7 +114,7 @@ jobs:
       if: always()
       id: codecov-flags
       run: |
-        echo ::set-output name=flags::$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")
+        echo flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))") >> $GITHUB_OUTPUT
 
     - name: Upload Project Code Coverage
       if: always()
@@ -252,7 +252,7 @@ jobs:
       if: always()
       id: codecov-flags
       run: |
-        echo ::set-output name=flags::$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")
+        echo flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))") >> $GITHUB_OUTPUT
 
     - name: Upload Project Code Coverage
       if: always()
@@ -385,7 +385,7 @@ jobs:
       if: always()
       id: codecov-flags
       run: |
-        echo ::set-output name=flags::$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")
+        echo flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))") >> $GITHUB_OUTPUT
 
     - name: Upload Project Code Coverage
       if: always()

--- a/project/.github/workflows/{% if workflows == 'org' %}tag.yml{% endif %}
+++ b/project/.github/workflows/{% if workflows == 'org' %}tag.yml{% endif %}
@@ -16,7 +16,7 @@ jobs:
 
       - name: Extract tag name
         id: get_version
-        run: echo "::set-output name=version::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "version=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
 
   call_central_workflow:
     needs: get_tag_version


### PR DESCRIPTION
This avoids deprecation annotations during workflow runs.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/