### PR TITLE
Fix SSH fixtures

### DIFF
--- a/project/tests/conftest.py.j2
+++ b/project/tests/conftest.py.j2
@@ -125,7 +125,21 @@ def sshd_server(salt_factories, sshd_config_dir):
 
 
 @pytest.fixture(scope="module")
-def salt_ssh_roster_file(sshd_server, master, current_user):
+def known_hosts_file(sshd_server, master, salt_factories):
+    with pytest.helpers.temp_file(
+        "ssh-known-hosts",
+        "\n".join(sshd_server.get_host_keys()),
+        salt_factories.tmp_root_dir,
+    ) as known_hosts_file, pytest.helpers.temp_file(
+        "master.d/ssh-known-hosts.conf",
+        f"known_hosts_file: {known_hosts_file}",
+        master.config_dir,
+    ):
+        yield known_hosts_file
+
+
+@pytest.fixture(scope="module")
+def salt_ssh_roster_file(sshd_server, master, known_hosts_file):  # pylint: disable=unused-argument
     roster_contents = f"""
     localhost:
       host: 127.0.0.1
@@ -134,6 +148,7 @@ def salt_ssh_roster_file(sshd_server, master, current_user):
     """
     if salt.utils.platform.is_darwin():
         roster_contents += "  set_path: $PATH:/usr/local/bin/\n"
+
     with pytest.helpers.temp_file("roster", roster_contents, master.config_dir) as roster_file:
         yield roster_file
 

--- a/project/tests/conftest.py.j2
+++ b/project/tests/conftest.py.j2
@@ -1,7 +1,6 @@
 import logging
 import os
 {%- if ssh_fixtures %}
-import pwd
 import shutil
 from pathlib import Path
 {%- endif %}
@@ -9,11 +8,18 @@ from pathlib import Path
 import pytest
 {%- if ssh_fixtures %}
 import salt.utils.platform
-import salt.utils.win_functions
 {%- endif %}
 from saltfactories.utils import random_string
 
 from {{ namespaced_package_pkg }} import PACKAGE_ROOT
+
+{%- if ssh_fixtures %}
+
+try:
+    import pwd
+except ImportError:
+    import salt.utils.win_functions
+{%- endif %}
 
 # Reset the root logger to its default level(because salt changed it)
 logging.root.setLevel(logging.WARNING)

--- a/project/tests/integration/conftest.py.j2
+++ b/project/tests/integration/conftest.py.j2
@@ -32,13 +32,14 @@ def salt_call_cli(minion):
 
 
 @pytest.fixture(scope="module")
-def salt_ssh_cli(master, salt_ssh_roster_file, sshd_config_dir):
+def salt_ssh_cli(
+    master, salt_ssh_roster_file, sshd_config_dir, known_hosts_file
+):  # pylint: disable=unused-argument
     return master.salt_ssh_cli(
         timeout=180,
         roster_file=salt_ssh_roster_file,
         target_host="localhost",
         client_key=str(sshd_config_dir / "client_key"),
-        base_script_args=["--ignore-host-keys"],
     )
 
 


### PR DESCRIPTION
* They crash on Windows (`pwd` is not available there)
* also don't ignore host keys (port from Salt core)