### PR TITLE
Fix tag workflow template

### DIFF
--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}tag.yml{% endif %}.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}tag.yml{% endif %}.j2
@@ -27,9 +27,9 @@ jobs:
 
   call_central_workflow:
     needs: get_tag_version
+{%- endraw %}
     uses: {{ base }}/.github/workflows/ci.yml{{ suffix }}
     with:
-{%- endraw %}
       deploy-docs: {{ (deploy_docs in ["rolling", "release"]) | lower }}
 {%- raw %}
       release: true


### PR DESCRIPTION
The template accidentally had some Jinja code wrapped in `raw` tags.