### PR TITLE
Ensure workflow permissions are correct for GH pages

### DIFF
--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}pr.yml{% endif %}.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}pr.yml{% endif %}.j2
@@ -5,6 +5,7 @@ name: Pull Request or Push
 {%-   set base = "salt-extensions/central-artifacts" %}
 {%-   set suffix = "@main" %}
 {%- endif %}
+{%- set deploy_docs_bool = deploy_docs == "rolling" %}
 {%- raw %}
 
 on:
@@ -20,10 +21,12 @@ jobs:
     name: CI
 {%- endraw %}
     uses: {{ base }}/.github/workflows/ci.yml{{ suffix }}
-{%- raw %}
+    with:
+      deploy-docs: {{ deploy_docs_bool | lower }}
     permissions:
       contents: write
+{%- if deploy_docs_bool %}
+      id-token: write
+      pages: write
+{%- endif %}
       pull-requests: read
-    with:
-{%- endraw %}
-      deploy-docs: {{ (deploy_docs == "rolling") | lower }}

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}tag.yml{% endif %}.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}tag.yml{% endif %}.j2
@@ -5,6 +5,7 @@ name: Tagged Releases
 {%-   set base = "salt-extensions/central-artifacts" %}
 {%-   set suffix = "@main" %}
 {%- endif %}
+{%- set deploy_docs_bool = deploy_docs in ["rolling", "release"] %}
 {%- raw %}
 
 on:
@@ -30,13 +31,18 @@ jobs:
 {%- endraw %}
     uses: {{ base }}/.github/workflows/ci.yml{{ suffix }}
     with:
-      deploy-docs: {{ (deploy_docs in ["rolling", "release"]) | lower }}
+      deploy-docs: {{ deploy_docs_bool | lower }}
 {%- raw %}
       release: true
       version: ${{ needs.get_tag_version.outputs.version }}
     permissions:
       contents: write
       id-token: write
+{%- endraw %}
+{%- if deploy_docs_bool %}
+      pages: write
+{%- endif %}
+{%- raw %}
       pull-requests: read
     secrets: inherit
 {%- endraw %}


### PR DESCRIPTION
The centralized workflow needs `id-token: write` and `pages: write` for docs deployment.