### PR TITLE
Centralized workflow always needs the permissions

### DIFF
--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}pr.yml{% endif %}.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}pr.yml{% endif %}.j2
@@ -5,7 +5,6 @@ name: Pull Request or Push
 {%-   set base = "salt-extensions/central-artifacts" %}
 {%-   set suffix = "@main" %}
 {%- endif %}
-{%- set deploy_docs_bool = deploy_docs == "rolling" %}
 {%- raw %}
 
 on:
@@ -22,11 +21,9 @@ jobs:
 {%- endraw %}
     uses: {{ base }}/.github/workflows/ci.yml{{ suffix }}
     with:
-      deploy-docs: {{ deploy_docs_bool | lower }}
+      deploy-docs: {{ (deploy_docs == "rolling") | lower }}
     permissions:
       contents: write
-{%- if deploy_docs_bool %}
       id-token: write
       pages: write
-{%- endif %}
       pull-requests: read

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}tag.yml{% endif %}.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/{% if workflows in ['org', 'enhanced'] %}tag.yml{% endif %}.j2
@@ -5,7 +5,6 @@ name: Tagged Releases
 {%-   set base = "salt-extensions/central-artifacts" %}
 {%-   set suffix = "@main" %}
 {%- endif %}
-{%- set deploy_docs_bool = deploy_docs in ["rolling", "release"] %}
 {%- raw %}
 
 on:
@@ -31,18 +30,14 @@ jobs:
 {%- endraw %}
     uses: {{ base }}/.github/workflows/ci.yml{{ suffix }}
     with:
-      deploy-docs: {{ deploy_docs_bool | lower }}
+      deploy-docs: {{ (deploy_docs in ["rolling", "release"]) | lower }}
 {%- raw %}
       release: true
       version: ${{ needs.get_tag_version.outputs.version }}
     permissions:
       contents: write
       id-token: write
-{%- endraw %}
-{%- if deploy_docs_bool %}
       pages: write
-{%- endif %}
-{%- raw %}
       pull-requests: read
     secrets: inherit
 {%- endraw %}


### PR DESCRIPTION
... even if the GH pages job is never called