### PR TITLE
Small fixes for meta files

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -240,6 +240,13 @@ coc_contact:
   help: Optionally provide a contact for Code of Conduct violation reports.
   default: ''
 
+copyright_begin:
+  help: Copyright range beginning year
+  type: int
+  default: '{{ "%Y" | strftime }}'
+  # Cannot use when: false to set this once automatically during
+  # creation since the value is not recorded then.
+
 # ===========================================
 # | Computed values for less ugly templates |
 # ===========================================
@@ -314,7 +321,6 @@ _templates_suffix: j2
 # We need those extensions as helpers
 _jinja_extensions:
   - copier_templates_extensions.TemplateExtensionLoader
-  - jinja_extensions/saltext.py:Year
   - jinja_extensions/saltext.py:YamlDumper
   - jinja_extensions/saltext.py:SaltExt
   - jinja2.ext.do

--- a/jinja_extensions/saltext.py
+++ b/jinja_extensions/saltext.py
@@ -1,5 +1,4 @@
 import copy
-from datetime import datetime
 from pathlib import Path
 
 import yaml
@@ -53,15 +52,6 @@ class SaltExt(ContextHook):
             "singular_loader_dirs": SINGULAR_LOADER_DIRS,
             "salt_latest_point": copy.deepcopy(self.slp),
         }
-
-
-class Year(ContextHook):
-    """
-    Provide the current year
-    """
-
-    def hook(self, context):
-        return {"copyright_year": datetime.now().year}
 
 
 def represent_str(dumper, data):

--- a/project/CODE-OF-CONDUCT.md.j2
+++ b/project/CODE-OF-CONDUCT.md.j2
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in Salt
-Extension Modules for Azure Resource Manager project and our community a
+Extension Modules for {{ integration_name or project_name.replace("-", " ").title() }} project and our community a
 harassment-free experience for everyone, regardless of age, body size, visible
 or invisible disability, ethnicity, sex characteristics, gender identity and
 expression, level of experience, education, socio-economic status, nationality,

--- a/project/docs/conf.py.j2
+++ b/project/docs/conf.py.j2
@@ -42,10 +42,10 @@ dist = distribution("{{ package_namespace_pkg }}{{ project_name }}")
 
 # -- Project information -----------------------------------------------------
 this_year = datetime.datetime.today().year
-if this_year == 2021:
-    copyright_year = 2021
+if this_year == {{ copyright_begin }}:
+    copyright_year = "{{ copyright_begin }}"
 else:
-    copyright_year = f"2021 - {this_year}"
+    copyright_year = f"{{ copyright_begin }} - {this_year}"
 project = dist.metadata["Summary"]
 author = dist.metadata.get("Author")
 

--- a/project/{% if license == 'apache' %}LICENSE{% endif %}.j2
+++ b/project/{% if license == 'apache' %}LICENSE{% endif %}.j2
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {{ copyright_year }} {{ author }}
+   Copyright {{ copyright_begin }} {{ author }}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/project/{% if license == 'apache' %}NOTICE{% endif %}.j2
+++ b/project/{% if license == 'apache' %}NOTICE{% endif %}.j2
@@ -1,5 +1,5 @@
 Salt Extension Modules for {{ integration_name or project_name.replace("-", " ").title() }}
-Copyright {{ copyright_year }} {{ author }}
+Copyright {{ copyright_begin }} {{ author }}
 
 This product is licensed to you under the Apache 2.0 license (the "License").
 You may not use this product except in compliance with the Apache 2.0 License.


### PR DESCRIPTION
* Ask for the copyright beginning year once, then use it correctly in docs and license files
* Drop `Year` ContextHook (just use `strftime`)
* Remove hard-coded reference to Azure Saltext