### PR TITLE
Fix skip_if_exists config

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -313,7 +313,7 @@ _subdirectory: project
 # Don't offer updates to implementation-specific files
 _skip_if_exists:
   - tests/**/test_*.py
-  - src/
+  - src/**/*_mod.py
 
 # Ensure we're compatible with the official tool
 _templates_suffix: j2


### PR DESCRIPTION
we need to match files exactly. Also, we don't want to skip the package init.