### PR TITLE
Minor adjustments

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -216,7 +216,7 @@ deploy_docs:
     When to automatically deploy CI built docs to GitHub Pages.
     Does not support versioned docs currently.
     Requires Settings > Pages > Build and deployment source to be `GitHub Actions`.
-  default: never
+  default: '{{ "rolling" if "github.com/salt-extensions/" in source_url else "never" }}'
   choices:
     never: never
     when tagging a release: release

--- a/copier.yml
+++ b/copier.yml
@@ -209,6 +209,7 @@ workflows:
     basic (== official creation tool): basic
     enhanced (~ organization, but local): enhanced
     organization (rely on centralized artifacts from salt-extensions org): org
+  when: '{{ "github.com" in source_url }}'
 
 deploy_docs:
   type: str

--- a/project/pyproject.toml.j2
+++ b/project/pyproject.toml.j2
@@ -30,7 +30,9 @@ classifiers = [
 {%- endfor %}
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+{%- if license_classifier %}
+    "{{ license_classifier }}",
+{%- endif %}
 ]
 requires-python = ">= {{ python_requires | join(".") }}"
 dynamic = ["version"]


### PR DESCRIPTION
* Make `rolling` doc releases the default for the org
* Don't ask workflow question on non-GH repos
* Ensure the license classifier is respected when license != apache