### PR TITLE
Allow to easily override daemon config in test suite

### DIFF
--- a/project/tests/conftest.py.j2
+++ b/project/tests/conftest.py.j2
@@ -45,13 +45,29 @@ def salt_factories_config():
 
 
 @pytest.fixture(scope="package")
-def master(salt_factories):
-    return salt_factories.salt_master_daemon(random_string("master-"))
+def master_config():
+    """
+    Salt master configuration overrides for integration tests.
+    """
+    return {}
 
 
 @pytest.fixture(scope="package")
-def minion(master):
-    return master.salt_minion_daemon(random_string("minion-"))
+def master(salt_factories, master_config):
+    return salt_factories.salt_master_daemon(random_string("master-"), overrides=master_config)
+
+
+@pytest.fixture(scope="package")
+def minion_config():
+    """
+    Salt minion configuration overrides for integration tests.
+    """
+    return {}
+
+
+@pytest.fixture(scope="package")
+def minion(master, minion_config):
+    return master.salt_minion_daemon(random_string("minion-"), overrides=minion_config)
 
 
 {%- if ssh_fixtures %}


### PR DESCRIPTION
Currently, it's not obvious how to override Salt configuration during integration tests.

This patch adds the corresponding fixtures to make the process clear.