### PR TITLE
DRY README, link docs on CLI, minor docs fixes/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,109 +1,44 @@
 # Create & Maintain Salt Extensions
 
-A [Copier](https://github.com/copier-org/copier) template that initializes a project structure for developing [Salt](https://github.com/saltstack/salt) extension modules.
+A [Copier](https://github.com/copier-org/copier) template that initializes a project structure for developing [Salt](https://github.com/saltstack/salt) [extension modules][saltext-def].
 
 ## Why
-For individual extension creators, this template allows to quickly get started with developing, testing and releasing new Salt functionality.
+For individual extension creators, this template allows to [quickly get started with developing][saltext-creation], [testing][saltext-testing] and [releasing][saltext-release] new Salt functionality.
 
-For extension maintainers and the `salt-extensions` organization, it ensures that there is a frictionless way of keeping the necessary boilerplate up to date.
+For extension maintainers and the [`salt-extensions` organization][gh-org-ref], it ensures that there is a frictionless way of keeping the necessary boilerplate [up to date][saltext-update].
 
 ## How
 
+For comprehensive instructions on all aspects of Salt extension development with this template, please refer to the [user documentation][docs].
+
 ![Preview](./docs/rec.svg)
 
-### Prerequisites
-At least [Copier](https://copier.readthedocs.io/en/latest/) version `9.1.0` is required (for [multiselect functionality](https://github.com/copier-org/copier/pull/1386)). It is generally recommended to install it via `pipx`:
-
-```bash
-pipx install copier
-```
-
-Furthermore, since this template provides some Jinja extensions, you need to ensure [copier-templates-extensions](https://github.com/copier-org/copier-templates-extensions) is present in the `copier` virtual environment:
-
-```bash
-pipx inject copier copier-templates-extensions
-```
-
-Note that `copier` has to be invoked with the `--trust` flag because of the included Python code that runs during template rendering. Please verify for yourself that it does not do anything nasty.
-
-### Creation
-Now, creating an extension project is as simple as running:
-
-```bash
-copier copy --trust https://github.com/salt-extensions/salt-extension-copier saltext-example
-```
-
-You are then presented with several questions, after which the project skeleton should be available. It additionally contains a `.copier-answers.yml` file with the inputs you gave, the URL of this repository plus the tag/commit ref that served as the base for the generated files. You should commit it together with the project.
-
-### First commit
-For specifics, please see the rendered `README.md` instructions. The following describes the general workflow with notes:
-
-Inside your project directory, initialize a git repository:
-
-```bash
-git init
-```
-
-Ensure you create a virtual environment for your extension and source it:
-
-```bash
-python -m venv venv --prompt 'saltext-example'
-source venv/bin/activate
-```
-
-Then, install the project inside the created environment in editable mode. This needs to be run inside a git repository, so ensure you have initialized it at this point:
-
-```bash
-python -m pip install -e '.[tests,dev,docs]'  # zsh requires the quotes
-```
-
-Ensure the pre-commit hook is installed:
-
-```bash
-pre-commit install
-```
-
-Then, you are ready to commit:
-
-```bash
-git add . && git commit -m "Initial commit"
-```
-
-Note that the pre-commit hooks might modify or create some files, which makes it fail. Just re-execute the command and all should be set.
-
-### Updating
-Future boilerplate updates can be as simple as:
-
-```bash
-copier update --trust --skip-answered
-```
-
-In case you want to update your answers to the questions as well as update:
-
-```bash
-copier update --trust
-```
-
-To just change your answers without updating, you need to specify the git ref found in your `.copier_answers.yml`:
-
-```bash
-copier update --trust --vcs-ref=$ref
-```
-
-Note that manually changing the inputs in the file is [strongly discouraged](https://copier.readthedocs.io/en/latest/updating/#never-change-the-answers-file-manually) by Copier.
-
-### Migration from official tool
-Existing projects can be migrated to this template by simply running the creation command over a clone of the existing repository. You should specify the `0.0.2` tag as a reference at the moment since this template diverges from the latest official release (`0.24.0`) after that.
+### Migration from the [deprecated tool][create-salt-extension]
+Existing projects can be migrated to this template by simply running the [creation commands][saltext-creation] on top of a repo clone. Ensure you additionally pass `--vcs-ref=0.0.2` to Copier since this template diverges from the last official release (`0.24.0`) after that.
 
 ```bash
 git clone https://github.com/salt-extensions/saltext-example
 copier copy --trust --vcs-ref=0.0.2 https://github.com/salt-extensions/salt-extension-copier saltext-example
 ```
 
-You are then presented with the same questions as during initialization. `copier` asks about conflict resolutions and afterwards creates `.copier-answers.yml`. There have likely been several modifications to the boilerplate since the extension was generated, so this can require some attention and could even reintroduce older dependencies. In the next step, you should thus update the project to the latest version.
+During this process, Copier asks about conflict resolutions. There have likely been several modifications to the boilerplate since the extension was generated, so this can require some attention and could even reintroduce older dependencies. Afterwards, you should [update the project][saltext-update] to the latest template version.
 
 ## References
-* `copier` docs: https://copier.readthedocs.io/en/latest/
-* An overview of modular systems in Salt: https://docs.saltproject.io/en/latest/topics/development/modules/index.html
-* The Salt-specific `pytest` docs: https://pytest-salt-factories.readthedocs.io/en/latest/
-* The `salt-extensions` organization: https://github.com/salt-extensions
+* [User documentation][docs] for this template
+* An overview of [modular systems in Salt][salt-modules]
+* [Salt-specific `pytest` docs][pytest-salt-factories]
+* [`salt-extensions` organization][gh-org]
+* [Copier docs][copier-docs]
+
+[docs]: https://salt-extensions.github.io/salt-extension-copier/
+[saltext-def]: https://salt-extensions.github.io/salt-extension-copier/ref/concepts.html#saltext-ref
+[saltext-creation]: https://salt-extensions.github.io/salt-extension-copier/topics/creation.html
+[saltext-testing]: https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html
+[saltext-release]: https://salt-extensions.github.io/salt-extension-copier/topics/publishing.html
+[gh-org-ref]: https://salt-extensions.github.io/salt-extension-copier/ref/concepts.html#gh-org-ref
+[saltext-update]: https://salt-extensions.github.io/salt-extension-copier/topics/updating.html
+[create-salt-extension]: https://github.com/saltstack/salt-extension
+[copier-docs]: https://copier.readthedocs.io/en/stable/
+[salt-modules]: https://docs.saltproject.io/en/latest/topics/development/modules/index.html
+[pytest-salt-factories]: https://pytest-salt-factories.readthedocs.io/en/latest/
+[gh-org]: https://github.com/salt-extensions/

--- a/copier.yml
+++ b/copier.yml
@@ -338,55 +338,32 @@ _jinja_extensions:
 
 # Before initialization, describe briefly what this is about
 _message_before_copy: |
+
   Welcome to salt-extension-copier!
 
   Even after generation, this template can be used to perform
   updates to your project's boilerplate.
 
-  Feel free to submit a PR if you think something should be improved. :)
+
+  Anything unclear? Visit the comprehensive user documentation:
+
+    ▶ https://salt-extensions.github.io/salt-extension-copier/
 
 # Describe next steps and rough usage after project initialization
 _message_after_copy: |
-  Your Salt extension project "{{ project_name_full }}" has been created successfully!
 
-  Next steps:
+  Your Salt extension project "{{ project_name_full }}" has been created successfully! 🎉
 
-  1. Change directory to the project root:
+  You should continue with the first steps documented here:
 
-     $ cd {{ _copier_conf.dst_path }}
+    ▶ https://salt-extensions.github.io/salt-extension-copier/topics/creation.html#first-steps
 
-  2. Initialize a Git repository:
+  {%- if "github.com/salt-extensions/" in source_url %}
 
-     $ git init
+  Once you're ready, submit a repository request to the organization:
 
-  3. Create a Python virtual environment:
-
-     $ python -m venv venv --prompt='{{ project_name_full }}'
-
-  4. Source it:
-
-     $ source venv/bin/activate
-
-  5. Install your project and dependencies in editable mode:
-
-     $ python -m pip install -e '.[dev,tests,docs]'
-
-  6. Install pre-commit hooks:
-
-     $ pre-commit install
-
-  7. Run the pre-commit hooks (the commit will fail the first time):
-
-     $ git add . && git commit
-
-  8. Perform the initial commit:
-
-     $ git add . && git commit -m "Initial extension layout"
-
-
-  To run the test suite:
-
-     $ nox -e tests-3
+    ▶ https://salt-extensions.github.io/salt-extension-copier/topics/organization/submitting.html
+  {%- endif %}
 
 
   Please update the tests :) Happy hacking!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,9 @@ tippy_rtd_urls = [
     "https://docs.pytest.org/en/stable",
 ]
 
+# Only show sneaky peeks in the `furo` main container, never in navigation
+tippy_anchor_parent_selector = "div.main"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/docs/ref/concepts.md
+++ b/docs/ref/concepts.md
@@ -13,7 +13,7 @@ loading system. They function similarly to custom modules found in `salt://_modu
 
 The Salt Project team has embarked on a significant transformation known as the "Great Module Migration." This initiative involves moving many modules, which were previously part of the core Salt distribution, into separate extensions. While this shift promises to streamline Salt’s core, it also means that many modules will no longer be maintained directly by the Salt team. Instead, their future now depends on community contributors.
 
-### Timeline and Key Events
+### Timeline and key events
 
 - **February 2016**: Salt extensions [were introduced](https://github.com/saltstack/salt/pull/31218) with the release of Salt 2016.9.
 - **November 2020**: A [major update](https://github.com/saltstack/salt/pull/58943) to Salt extensions was released in Salt 3003. [Watch the Salt Extension Overview](https://www.youtube.com/watch?v=hhomJkwxK3Q) video for more details.
@@ -24,7 +24,7 @@ The Salt Project team has embarked on a significant transformation known as the 
 - **February 2024**: The [Great Module Purge PR](https://github.com/saltstack/salt/pull/65971) was created.
 - **April 2024**: The Great Module Purge PR was merged, making 3008 the target release.
 
-### Why This Change?
+### Why this change?
 
 This drastic change is driven by several key goals:
 
@@ -34,7 +34,7 @@ This drastic change is driven by several key goals:
 4. **Efficient Salt Distributions**: Release platform-specific versions of Salt that are smaller and more efficient.
 5. **Faster Development**: With fewer modules in the core, testing and review times will decrease, accelerating development.
 
-### Categories of Modules
+### Categories of modules
 
 The migration splits modules into three categories:
 
@@ -43,7 +43,7 @@ The migration splits modules into three categories:
 (community-modules-target)=
 3. **Community Modules**: These will be removed from the Salt Core codebase. Community members can take over their maintenance, either in the community-run Salt Extensions GitHub organization or in their own repositories.
 
-### Why You Should Get Involved
+### Why you should get involved
 
 In conclusion, this migration represents a shift in how Salt is maintained and developed. It opens the door for users and organizations to have a direct impact on the tools they rely on. If you use any of the modules categorized as community modules, their future depends on people like you. By becoming a maintainer or contributor, you can ensure that the modules you depend on continue to thrive and evolve.
 

--- a/docs/topics/documenting/index.md
+++ b/docs/topics/documenting/index.md
@@ -4,9 +4,10 @@ Your Salt extension's documentation is generated using [sphinx](https://www.sphi
 
 The environment setup and `sphinx` invocation are managed by [nox](https://nox.thea.codes/en/stable/).
 
+## Quick links
+
 ```{toctree}
-:maxdepth: 2
-:hidden:
+:maxdepth: 4
 
 building
 writing

--- a/docs/topics/extraction.md
+++ b/docs/topics/extraction.md
@@ -347,4 +347,4 @@ For modules that can work with multiple interchangeable libraries, declare at le
 (dedicated-docs)=
 ### Dedicated docs
 
-Salt core modules often include inline documentation. Consider extracting the general parts of this inline documentation into separate topics within the {path}`docs/topics`directory.
+Salt core modules often include inline documentation. Consider extracting the general parts of this inline documentation into separate topics within the {path}`docs/topics` directory.

--- a/docs/topics/organization/index.md
+++ b/docs/topics/organization/index.md
@@ -28,9 +28,10 @@ You can also engage with the community on the organization’s [GitHub discussio
 
 [discord-invite]: https://discord.gg/bPah23K7mG
 
+## Quick links
+
 ```{toctree}
 :maxdepth: 2
-:hidden:
 
 submitting
 ```

--- a/docs/topics/testing/index.md
+++ b/docs/topics/testing/index.md
@@ -4,9 +4,10 @@ Your Salt extension's test suite is based on [pytest](https://docs.pytest.org/en
 
 The environment setup and `pytest` invocation are managed by [nox](https://nox.thea.codes/en/stable/).
 
+## Quick links
+
 ```{toctree}
-:maxdepth: 2
-:hidden:
+:maxdepth: 4
 
 running
 writing


### PR DESCRIPTION
* Remove redundant information from this project's README, link to now hosted docs instead
* link to hosted docs on CLI
* minor docs improvements

Fixes: https://github.com/salt-extensions/salt-extension-copier/issues/15
Fixes: https://github.com/salt-extensions/salt-extension-copier/issues/40