### PR TITLE
Raise some Pylint maximum counts

### DIFF
--- a/project/.pylintrc.j2
+++ b/project/.pylintrc.j2
@@ -329,10 +329,10 @@ ignored-parents=
 max-args=35
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=15
 
 # Maximum number of boolean expressions in an if statement (see R0916).
-max-bool-expr=5
+max-bool-expr=8
 
 # Maximum number of branch for function / method body.
 max-branches=48
@@ -347,7 +347,7 @@ max-parents=7
 max-public-methods=25
 
 # Maximum number of return / yield for function / method body.
-max-returns=6
+max-returns=10
 
 # Maximum number of statements in function / method body.
 max-statements=100

--- a/project/noxfile.py.j2
+++ b/project/noxfile.py.j2
@@ -8,6 +8,7 @@
     "attribute-defined-outside-init",
     "inconsistent-return-statements",
     "too-few-public-methods",
+    "too-many-public-methods",
 ] -%}
 
 {%- if relax_pylint -%}


### PR DESCRIPTION
Followup to https://github.com/salt-extensions/salt-extension-copier/pull/44.

... did not save the buffer previously. We don't want to be too strict by default, just a nudge.

The values were lower previously, but the messages were ignored altogether.