### PR TITLE
Ignore keyword-arg-before-vararg pylint warning by default

### DIFF
--- a/changelog/+pylint-vararg.changed.md
+++ b/changelog/+pylint-vararg.changed.md
@@ -1,0 +1,1 @@
+Ignored keyword-arg-before-vararg pylint warning by default because `salt.utils.args.get_function_argspec` does not work with this style

--- a/project/.pylintrc.j2
+++ b/project/.pylintrc.j2
@@ -1,6 +1,7 @@
 {%- set disable = [
   "duplicate-code",
   "fixme",
+  "keyword-arg-before-vararg",
   "line-too-long",
   "logging-fstring-interpolation",
   "missing-class-docstring",


### PR DESCRIPTION
because the suggested style does not work with salt.utils.args.get_function_argspec.