### PR TITLE
Fix project environment initialization crash during first copy

### DIFF
--- a/changelog/+initcrash.fixed.md
+++ b/changelog/+initcrash.fixed.md
@@ -1,0 +1,1 @@
+Fixed project environment initialization crash during first copy. This crash did not result in any issues other than a warning after copy.

--- a/project/tools/helpers/pre_commit.py
+++ b/project/tools/helpers/pre_commit.py
@@ -103,6 +103,13 @@ def run_pre_commit(venv, retries=2):
             prompt.warn(f"✗ Failing hook ({i + 1}): {failing_hook}", failing[failing_hook])
     finally:
         if new_files:
-            # Undo git add --intent-to-add to allow RenovateBot to detect new files correctly
-            git("restore", "--staged", *new_files)
+            try:
+                # Check if there is at least one commit in the repo,
+                # otherwise git restore --staged fails.
+                git("rev-parse", "HEAD")
+            except ProcessExecutionError:
+                pass
+            else:
+                # Undo git add --intent-to-add to allow RenovateBot to detect new files correctly
+                git("restore", "--staged", *new_files)
     return False


### PR DESCRIPTION
`git restore --staged .` requires a HEAD, which is not present when the repo has just been initialized (ie missing the initial commit). This caused a crash in the env initialization script, which resulted in a warning after `copier copy` (nothing else though).