### PR TITLE
Drop support for Python 3.8 (EOL)

### DIFF
--- a/changelog/+py38.removed.md
+++ b/changelog/+py38.removed.md
@@ -1,0 +1,1 @@
+Dropped Python 3.8 support

--- a/data/salt_python_support.yaml
+++ b/data/salt_python_support.yaml
@@ -2,21 +2,21 @@
 3003:
   min:
     - 3
-    - 8
+    - 9
   max:
     - 3
     - 9
 3004:
   min:
     - 3
-    - 8
+    - 9
   max:
     - 3
     - 10
 3005:
   min:
     - 3
-    - 8
+    - 9
   max:
     - 3
     - 10
@@ -24,7 +24,7 @@
   lts: true
   min:
     - 3
-    - 8
+    - 9
   max:
     - 3
     - 10
@@ -34,7 +34,7 @@
 3007:
   min:
     - 3
-    - 8
+    - 9
   max:
     - 3
     - 10  # 3.11/3.12 have pinned requirements, but they are not stable yet


### PR DESCRIPTION
It was already dropped by upgrading the coverage version, which broke CI. This just ensures the generated workflows work as expected.