### PR TITLE
Remove libeay32 download from repo.saltproject.io

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -81,18 +81,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Download libeay32.dll
-        run: |
-          PY_LOC="$(which python.exe)"
-          export PY_LOC
-          echo "${PY_LOC}"
-          PY_DIR="$(dirname "${PY_LOC}")"
-          export PY_DIR
-          echo "${PY_DIR}"
-          curl https://repo.saltproject.io/windows/dependencies/64/libeay32.dll --output "${PY_DIR}/libeay32.dll"
-          ls -l "${PY_DIR}"
-        shell: bash
-
       - name: Install Nox
         run: |
           python -m pip install --upgrade pip

--- a/changelog/+libeay32.fixed.md
+++ b/changelog/+libeay32.fixed.md
@@ -1,0 +1,1 @@
+Fixed Windows test runs after repo.saltproject.io decommission

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/test-action.yml.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/test-action.yml.j2
@@ -181,18 +181,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Download libeay32.dll
-        run: |
-          PY_LOC="$(which python.exe)"
-          export PY_LOC
-          echo "${PY_LOC}"
-          PY_DIR="$(dirname "${PY_LOC}")"
-          export PY_DIR
-          echo "${PY_DIR}"
-          curl https://repo.saltproject.io/windows/dependencies/64/libeay32.dll --output "${PY_DIR}/libeay32.dll"
-          ls -l "${PY_DIR}"
-        shell: bash
-
       - name: Install Nox
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Fixes test suite runs on Windows after `repo.saltproject.io` was sunset.

Basic testing seems to keep working without this dependency (https://github.com/salt-extensions/saltext-mysql/pull/11), not sure why it was necessary. We'll see if anything breaks.