### PR TITLE
fix: venv Python version selection with uv

### DIFF
--- a/changelog/+uvpyver.fixed.md
+++ b/changelog/+uvpyver.fixed.md
@@ -1,0 +1,1 @@
+Fixed venv Python version selection with uv

--- a/project/tools/helpers/venv.py
+++ b/project/tools/helpers/venv.py
@@ -47,13 +47,12 @@ def create_venv(project_root=".", directory=None):
         prompt.status("Found `uv`. Creating venv")
         uv(
             "venv",
+            # Install pip/setuptools/wheel for compatibility
+            "--seed",
             "--python",
             RECOMMENDED_PYVER,
             f"--prompt=saltext-{discover_project_name()}",
         )
-        prompt.status("Installing pip into venv")
-        # Ensure there's still a `pip` (+ setuptools/wheel) inside the venv for compatibility
-        uv("venv", "--seed")
     else:
         prompt.status("Did not find `uv`. Falling back to `venv`")
         try:


### PR DESCRIPTION
The separate call creates a new venv with the default Python.