### PR TITLE
Support Copier 9.6+

### DIFF
--- a/changelog/148.fixed.md
+++ b/changelog/148.fixed.md
@@ -1,0 +1,1 @@
+Added support for Copier 9.6+, raised minimum Copier version to 9.6.0

--- a/copier.yml
+++ b/copier.yml
@@ -392,20 +392,16 @@ _tasks:
   # This breaks when recopying.
   # We should be able to simplify this check in the future to:
   # if _copier_conf.operation == "copy".
-  - >-
-    {%- if
-      not _copier_conf.answers.last
-      and '.new_copy.' not in _copier_conf.dst_path.name
-      and '.old_copy.' not in _copier_conf.dst_path.name -%}
-        "{{ _copier_python }}" "{{ "{src}{sep}tasks{sep}initialize.py".format(src=_copier_conf.src_path, sep=_copier_conf.sep) }}" init
-    {%- endif -%}
+  - command: >-
+      "{{ _copier_python }}" "{{ "{src}{sep}tasks{sep}initialize.py".format(src=_copier_conf.src_path, sep=_copier_conf.sep) }}" init
+    when: '{{ _copier_operation == "copy" }}'
 
 # =====================================
 # | Copier settings for this template |
 # =====================================
 
-# We need the new migration syntax
-_min_copier_version: "9.3.0"
+# We need the _copier_operation variable
+_min_copier_version: "9.6.0"
 
 # The template root is found here
 _subdirectory: project

--- a/docs/topics/installation.md
+++ b/docs/topics/installation.md
@@ -10,14 +10,14 @@ It’s recommended to install Copier globally using either [uv][uv-docs] or [pip
 
 
 ```bash
-uv tool install --python 3.10 --with copier-templates-extensions 'copier>=9.3,<9.5'
+uv tool install --python 3.10 --with copier-templates-extensions 'copier>=9.6'
 ```
 :::
 
 :::{tab} pipx
 
 ```bash
-pipx install 'copier>=9.3,<9.5' && \
+pipx install 'copier>=9.6' && \
  pipx inject copier copier-templates-extensions
 ```
 :::
@@ -27,7 +27,7 @@ pipx install 'copier>=9.3,<9.5' && \
 Alternatively, you can install Copier with `pip`, preferably inside a virtual environment:
 
 ```bash
-python -m pip install 'copier>=9.3,<9.5' copier-templates-extensions
+python -m pip install 'copier>=9.6' copier-templates-extensions
 ```
 :::
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,7 +60,7 @@ DOCS_REQUIREMENTS = (
 DOCSAUTO_REQUIREMENTS = ("sphinx-autobuild",)
 
 TESTS_REQUIREMENTS = (
-    "copier>=9.3,<9.5",
+    "copier>=9.6",
     "copier-templates-extensions",
     "plumbum",
     "pytest",


### PR DESCRIPTION
Copier 9.5 broke the workaround for not having _copier_operation, which
9.6 introduced. This removes the broken workaround and relies on the new
variable, which means we need at least Copier 9.6.0 to render the
template going forward.
