### PR TITLE
Fix CI and dev envs with uv >= 0.6.0

### DIFF
--- a/changelog/+uv060.fixed.md
+++ b/changelog/+uv060.fixed.md
@@ -1,0 +1,1 @@
+Fixed CI and dev environments with uv>=0.6.0 (Salt's dependencies were never installed, causing an ImportError for `looseversion`)

--- a/project/pyproject.toml.j2
+++ b/project/pyproject.toml.j2
@@ -100,6 +100,11 @@ tests = [
 [project.entry-points."salt.loader"]
 "{{ package_namespace_pkg }}{{ project_name }}" = "{{ namespaced_package_pkg }}"
 
+[tool.uv]
+# Salt's legacy setup.py requires old setuptools.
+# Since uv 0.6.0, it does not fall back to reading requirements from egg-info.
+build-constraint-dependencies = ["setuptools<69"]
+
 [tool.setuptools]
 zip-safe = false
 include-package-data = true


### PR DESCRIPTION
`uv<0.6` releases used `requires.txt` from `egg-info` of the sdist as a
fallback. This has been changed. Since Salt requires its legacy
`setup.py`, which in turn requires `setuptools<69`, it could not be
built properly and its dependencies were never installed.

This constrains setuptools for all package builds. In theory, we
could limit this to the installation of Salt in `noxfile.py`, but the
`--build-constraint` parameter requires a file, which would need to be
included or created ad-hoc. Constraining setuptools in this way should
not cause problems in the near future, otherwise we can go this more
complicated way. I might have missed something since I'm not a Python
packaging pro. Better suggestions are welcome.
