### PR TITLE
Constrain setuptools in package build workflow

### DIFF
--- a/changelog/+setuptools77.fixed.md
+++ b/changelog/+setuptools77.fixed.md
@@ -1,0 +1,1 @@
+Fixed release workflow after the release of seuptools 77

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/get-changed-files.yml.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/get-changed-files.yml.j2
@@ -45,6 +45,15 @@ jobs:
                 - .pre-commit-config.y?(a)ml
                 - .pylintrc
                 - pyproject.toml
+            # If files in this filter change, a test release to TestPyPI
+            # should be attempted. This is currently not implemented yet.
+            release:
+              - added|modified|deleted:
+                - .copier-answers.y?(a)ml
+                - .github/workflows/**
+                - CHANGELOG.md
+                - pyproject.toml
+                - setup.py
 
       - name: Echo Changed Files Output
         run: echo "${{ toJSON(steps.changed-files.outputs) }}"

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/package-action.yml.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/package-action.yml.j2
@@ -32,14 +32,18 @@ jobs:
           python -m
           pip install
           build
-          setuptools_scm
           --user
 
       - name: Echo Version
         run: echo "${{ inputs.version }}"
 
       - name: Build Wheel
-        run: python -m build --outdir dist/
+        run: |
+          # The version of our PyPA publish action (specifically the twine version used in it)
+          # does not support Core Metadata 2.4, which was introduced in setuptools release 77.
+          # We cannot upgrade it until the release workflow has been refactored into standalone one.
+          echo "setuptools<77" > "$RUNNER_TEMP/build-constraints.txt"
+          PIP_CONSTRAINT="$RUNNER_TEMP/build-constraints.txt" python -m build --outdir dist/
 
       - name: Upload build artifacts
 {%- endraw %}

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/pre-commit-action.yml.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/pre-commit-action.yml.j2
@@ -16,7 +16,7 @@ jobs:
 {%- endraw %}
     runs-on: ubuntu-{{ versions["ubuntu"] }}
     container:
-      image: docker.io/library/python:{{ versions["python_container"] }}
+      image: 'docker.io/library/python:{{ versions["python_container"] }}'
 {%- raw %}
 
     steps:


### PR DESCRIPTION
`setuptools` 77 introduced Core Metadata 2.4, which cannot be read by the
twine version used in `pypa/gh-action-pypi-publish` v1.11.0.
This in turn cannot be upgraded until we have refactored the release
workflow into a standalone one (not part of the reusable `CI` workflow)
(see commit b948cff46edef08cd2de16e5c2dae0a2feb2960d / https://github.com/salt-extensions/salt-extension-copier/issues/167).

TLDR: This fixes package releases, again.