### PR TITLE
Fix rendering with Copier 9.7+

### DIFF
--- a/changelog/+noxpip.fixed.md
+++ b/changelog/+noxpip.fixed.md
@@ -1,0 +1,1 @@
+Fixed nox test session when uv is unavailable

--- a/changelog/196.fixed.md
+++ b/changelog/196.fixed.md
@@ -1,0 +1,1 @@
+Fixed rendering with Copier 9.7+

--- a/copier.yml
+++ b/copier.yml
@@ -181,7 +181,14 @@ python_requires:
     {%- import "data/salt_python_support.yaml" as sps -%}
     {%- set sup = sps | string | from_yaml -%}
     {%- set minsup = sup[salt_version | float | int]["min"] -%}
-    {%- set selected = python_requires.split(".") | map("int") | list -%}
+    {%- set selected = python_requires -%}
+    {%- if selected is string -%}
+    {#-   Copier 9.6 does not run context hooks here (transforms this into a tuple).
+          We don't need to adjust minsup to a list since it's loaded directly from YAML
+          when context hooks are not run.
+    -#}
+    {%-   set selected = selected.split(".") | map("int") | list -%}
+    {%- endif -%}
     {%- if selected < minsup -%}
     Minimum supported Python version of Salt {{ salt_version }} is {{ minsup | join(".") }}
     {%- endif -%}

--- a/copier.yml
+++ b/copier.yml
@@ -152,20 +152,24 @@ salt_version:
   help: Minimum Salt version to support
   default: '3006'
   validator: >-
-    {%- import "data/salt_python_support.yaml" as sps -%}
-    {%- set sup = sps | string | from_yaml -%}
-    {%- if salt_version | float | int not in sup -%}
-      Unknown Salt version. Known major: {{ sup | join(", ") }}
+    {%- if salt_python_support is not defined -%}
+    {%-   import "data/salt_python_support.yaml" as sps -%}
+    {%-   set salt_python_support = sps | string | from_yaml -%}
+    {%- endif -%}
+    {%- if salt_version | float | int not in salt_python_support -%}
+      Unknown Salt version. Known major: {{ salt_python_support | join(", ") }}
     {%- endif -%}
     {%- if "." in salt_version -%}
     {%-   if salt_version.count(".") > 1 -%}
       Unknown Salt version format. Allowed: MAJOR, MAJOR.MINOR
     {%-   else -%}
-    {%-     import "data/salt_latest_point.yaml" as spr -%}
-    {%-     set slp = spr | string | from_yaml -%}
+    {%-     if salt_latest_point is not defined -%}
+    {%-       import "data/salt_latest_point.yaml" as slp -%}
+    {%-       set salt_latest_point = slp | string | from_yaml -%}
+    {%-     endif -%}
     {%-     set major, minor = salt_version.split(".") | map("int") -%}
-    {%-     if slp[major] < minor -%}
-      Unknown minor release. Latest known: {{ major }}.{{ slp[major] }}
+    {%-     if salt_latest_point[major] < minor -%}
+      Unknown minor release. Latest known: {{ major }}.{{ salt_latest_point[major] }}
     {%-     endif -%}
     {%-   endif -%}
     {%- endif -%}
@@ -174,13 +178,17 @@ python_requires:
   type: str
   help: Minimum Python version to support
   default: >-
-    {%- import "data/salt_python_support.yaml" as sps -%}
-    {%- set sup = sps | string | from_yaml -%}
-    {{- sup[salt_version | float | int]["min"] | join(".") -}}
+    {%- if salt_python_support is not defined -%}
+    {%-   import "data/salt_python_support.yaml" as sps -%}
+    {%-   set salt_python_support = sps | string | from_yaml -%}
+    {%- endif -%}
+    {{- salt_python_support[salt_version | float | int]["min"] | join(".") -}}
   validator: >-
-    {%- import "data/salt_python_support.yaml" as sps -%}
-    {%- set sup = sps | string | from_yaml -%}
-    {%- set minsup = sup[salt_version | float | int]["min"] -%}
+    {%- if salt_python_support is not defined -%}
+    {%-   import "data/salt_python_support.yaml" as sps -%}
+    {%-   set salt_python_support = sps | string | from_yaml -%}
+    {%- endif -%}
+    {%- set minsup = salt_python_support[salt_version | float | int]["min"] -%}
     {%- set selected = python_requires -%}
     {%- if selected is string -%}
     {#-   Copier 9.6 does not run context hooks here (transforms this into a tuple).
@@ -198,20 +206,24 @@ max_salt_version:
   help: The maximum Salt major version to support
   default: '3007'
   validator: >-
-    {%- import "data/salt_python_support.yaml" as sps -%}
-    {%- set sup = sps | string | from_yaml -%}
-    {%- if max_salt_version | float | int not in sup -%}
-      Unknown Salt version. Known major: {{ sup | join(", ") }}
+    {%- if salt_python_support is not defined -%}
+    {%-   import "data/salt_python_support.yaml" as sps -%}
+    {%-   set salt_python_support = sps | string | from_yaml -%}
+    {%- endif -%}
+    {%- if max_salt_version | float | int not in salt_python_support -%}
+      Unknown Salt version. Known major: {{ salt_python_support | join(", ") }}
     {%- endif -%}
     {%- if "." in max_salt_version -%}
     {%-   if max_salt_version.count(".") > 1 -%}
       Unknown Salt version format. Allowed: MAJOR, MAJOR.MINOR
     {%-   else -%}
-    {%-     import "data/salt_latest_point.yaml" as spr -%}
-    {%-     set slp = spr | string | from_yaml -%}
+    {%-     if salt_latest_point is not defined -%}
+    {%-       import "data/salt_latest_point.yaml" as slp -%}
+    {%-       set salt_latest_point = slp | string | from_yaml -%}
+    {%-     endif -%}
     {%-     set major, minor = max_salt_version.split(".") | map("int") -%}
-    {%-     if slp[major] < minor -%}
-      Unknown minor release. Latest known: {{ major }}.{{ slp[major] }}
+    {%-     if salt_latest_point[major] < minor -%}
+      Unknown minor release. Latest known: {{ major }}.{{ salt_latest_point[major] }}
     {%-     endif -%}
     {%-   endif -%}
     {%- endif -%}
@@ -346,11 +358,13 @@ salt_version_minor:
   when: false
   default: >-
     {%- if "." in salt_version -%}
-      {{- salt_version.split(".") | last -}}
+     {{- salt_version.split(".") | last -}}
     {%- else -%}
-      {%- import "data/salt_latest_point.yaml" as spr -%}
-      {%- set slp = spr | string | from_yaml -%}
-      {{- slp[salt_version_major] -}}
+    {%-   if salt_latest_point is not defined -%}
+    {%-     import "data/salt_latest_point.yaml" as slp -%}
+    {%-     set salt_latest_point = slp | string | from_yaml -%}
+    {%-   endif -%}
+      {{- salt_latest_point[salt_version_major] -}}
     {%- endif -%}
 
 max_salt_version_major:
@@ -365,18 +379,22 @@ max_salt_version_minor:
     {%- if "." in max_salt_version -%}
       {{- max_salt_version.split(".") | last -}}
     {%- else -%}
-      {%- import "data/salt_latest_point.yaml" as spr -%}
-      {%- set slp = spr | string | from_yaml -%}
-      {{- slp[max_salt_version_major] -}}
+    {%-   if salt_latest_point is not defined -%}
+    {%-     import "data/salt_latest_point.yaml" as slp -%}
+    {%-     set salt_latest_point = slp | string | from_yaml -%}
+    {%-   endif -%}
+      {{- salt_latest_point[max_salt_version_major] -}}
     {%- endif -%}
 
 max_python_minor:
   type: int
   when: false
   default: >-
-    {%- import "data/salt_python_support.yaml" as sps -%}
-    {%- set sup = sps | string | from_yaml -%}
-    {{- sup[max_salt_version_major]["max"][1] -}}
+    {%- if salt_python_support is not defined -%}
+    {%-   import "data/salt_python_support.yaml" as sps -%}
+    {%-   set salt_python_support = sps | string | from_yaml -%}
+    {%- endif -%}
+    {{- salt_python_support[max_salt_version_major]["max"][1] -}}
 
 # ========================================
 # | Migrations between template versions |

--- a/copier.yml
+++ b/copier.yml
@@ -432,9 +432,9 @@ _min_copier_version: "9.6.0"
 _subdirectory: project
 
 # Don't offer updates to implementation-specific files
-_skip_if_exists:
-  - tests/**/test_*.py
-  - src/**/*_mod.py
+_exclude:
+  - '{%- if _copier_operation != "copy" %}tests/**/test_*.py{%- endif %}'
+  - '{%- if _copier_operation != "copy" %}src/**/*_mod.py{%- endif %}'
 
 # Ensure we're compatible with the official tool
 _templates_suffix: j2

--- a/jinja_extensions/saltext.py
+++ b/jinja_extensions/saltext.py
@@ -50,16 +50,18 @@ class SaltExt(ContextHook):
         )
 
     def hook(self, context):
-        if "python_requires" not in context:
-            # This happens during pre-copy message rendering
-            return {}
-        return {
-            "python_requires": tuple(int(x) for x in context["python_requires"].split(".")),
-            "salt_python_support": copy.deepcopy(self.sps),
-            "singular_loader_dirs": SINGULAR_LOADER_DIRS,
-            "salt_latest_point": copy.deepcopy(self.slp),
-            "versions": copy.deepcopy(self.versions),
-        }
+        if "python_requires" in context:
+            context["python_requires"] = tuple(
+                int(x) for x in context["python_requires"].split(".")
+            )
+        context.update(
+            {
+                "salt_python_support": copy.deepcopy(self.sps),
+                "singular_loader_dirs": SINGULAR_LOADER_DIRS,
+                "salt_latest_point": copy.deepcopy(self.slp),
+                "versions": copy.deepcopy(self.versions),
+            }
+        )
 
 
 def represent_str(dumper, data):

--- a/project/noxfile.py.j2
+++ b/project/noxfile.py.j2
@@ -123,7 +123,21 @@ def _install_requirements(
             session.install(no_progress, COVERAGE_REQUIREMENT, silent=PIP_INSTALL_SILENT)
 
         if install_salt:
-            session.install(no_progress, SALT_REQUIREMENT, silent=PIP_INSTALL_SILENT)
+            # Salt does not publish wheels and setuptools 75.6.0+ breaks requirements inclusion during builds,
+            # so we need to constrain setuptools in the build environment. uv reads this from
+            # pyproject.toml, but pip has no equivalent behavior.
+            # We need delete=False for Windows. delete_on_close would work, but is Python 3.12+ only.
+            with tempfile.NamedTemporaryFile(delete=False) as constraints_file:
+                setuptools_constraint = "setuptools<75.6.0"
+                constraints_file.write(setuptools_constraint.encode())
+            env = {
+                "PIP_CONSTRAINT": constraints_file.name,
+            }
+            try:
+                session.install(no_progress, SALT_REQUIREMENT, silent=PIP_INSTALL_SILENT, env=env)
+            finally:
+                os.unlink(constraints_file.name)
+
 
         if install_test_requirements:
             install_extras.append("tests")

--- a/project/pyproject.toml.j2
+++ b/project/pyproject.toml.j2
@@ -59,7 +59,7 @@ Tracker = "{{ tracker_url }}"
 [project.optional-dependencies]
 changelog = ["towncrier=={{ versions["towncrier"] }}"]
 dev = [
-    "nox[uv]>=2024.3",
+    "nox[uv]>=2024.3,!=2025.05.01",
     "pre-commit>=2.21.0",
 ]
 # These dependencies are used in automations. It can be helpful

--- a/tasks/initialize.py
+++ b/tasks/initialize.py
@@ -1,7 +1,5 @@
-import fnmatch
 import os
 import sys
-from pathlib import Path
 
 from task_helpers.pythonpath import project_tools
 
@@ -9,7 +7,6 @@ with project_tools():
     from helpers import prompt
     from helpers.copier import finish_task
     from helpers.git import ensure_git
-    from helpers.git import list_untracked
     from helpers.pre_commit import run_pre_commit
     from helpers.venv import ensure_project_venv
 
@@ -19,16 +16,6 @@ SKIP_IF_EXISTS_BOILERPLATE = (
     "src/**/*_mod.py",
     "tests/**/test_*.py",
 )
-
-
-def remove_untracked_unwanted():
-    """
-    Fix Copier regenerating paths listed in skip_if_exists on updates until
-    _copier_conf.operation is merged.
-    """
-    for path in list_untracked():
-        if any(fnmatch.fnmatch(path, ptrn) for ptrn in SKIP_IF_EXISTS_BOILERPLATE):
-            Path(path).unlink()
 
 
 if __name__ == "__main__":
@@ -51,8 +38,6 @@ if __name__ == "__main__":
     try:
         prompt.ensure_utf8()
         ensure_git()
-        if not init:
-            remove_untracked_unwanted()
         venv = ensure_project_venv()
         if not run_pre_commit(venv):
             finish_task(

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -188,6 +188,8 @@ def test_first_commit_works(project):
 )
 def test_testsuite_works(project, project_venv):
     with local.cwd(project.project_dir):
+        # Force re-build of Salt in case pip cache includes corrupt wheel
+        project_venv.run_module("pip", "cache", "remove", "salt")
         res = project_venv.run_module("nox", "-e", "tests-3", check=False)
     assert res.returncode == 0
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -77,13 +77,27 @@ def test_project_init_works(copie, answers, capfd):
 
 
 @pytest.mark.parametrize("skip_init_migrate", (False,), indirect=True)
-@pytest.mark.parametrize("project", ("0.2.0",), indirect=True)
+@pytest.mark.parametrize("project", ("0.7.2",), indirect=True)
 def test_project_migration_works(copie, project, project_venv, request, capfd):
-    def _check_version(expected):
-        curr = project_venv.run_module("pre_commit", "--version").stdout.split()[-1]
-        assert (curr == "2.13.0") is expected
+    """
+    Ensure the generated project can be updated as expected
+    and the virtualenv is reinstalled after with new requirements.
 
-    assert not (new_file := project.project_dir / "CODE-OF-CONDUCT.md").exists()
+    Because of several breaking changes in Copier and a bug in
+    version 0.6.0 venv Python selection, we cannot test this
+    reliably with versions below 0.7.2, which has been hotfixed
+    to work with Copier 9.7+.
+    """
+
+    def _check_version(expected):
+        out = project_venv.run_module("nox", "--version")
+        curr = out.stderr.strip()
+        assert (curr == "2023.4.22") is expected
+
+    # This is the tagged version of actions/setup-python in version 0.7.2
+    indicator = "42375524e23c412d93fb67b49958b491fce71c38"
+    docs_action = project.project_dir / ".github" / "workflows" / "docs-action.yml"
+    assert indicator in docs_action.read_text()
     # delete boilerplate, should not be regenerated after update
     # also, all of this makes pylint fail
     boilerplate = [
@@ -96,17 +110,21 @@ def test_project_migration_works(copie, project, project_venv, request, capfd):
     ]
     for bpl in boilerplate:
         bpl.unlink()
-    # downgrade pre-commit below required version
-    project_venv.install("pre-commit==2.13.0")
+    # downgrade nox below minimum version
+    project_venv.install("nox==2023.4.22")
     _check_version(True)
     request.getfixturevalue("project_committed")
-    res = copie.update(project)
+    # TODO: When there is 0.7.4 or similar, remove vcs_ref again.
+    # This is needed because 0.7.3 and 0.7.2 point to different branches
+    # because of a hotfix, so Copier thinks we're upgrading to 0.7.1-postsomething
+    # when not specifying a specific tag.
+    res = copie.update(project, vcs_ref="0.7.3")
     _assert_worked(res)
     # ensure the environment migration did not fail
     # (it does not cause an exit code > 0 since it's optional)
     assert "Failed migrating environment" not in capfd.readouterr().err
     # ensure the upgrade worked
-    assert new_file.exists()
+    assert indicator not in docs_action.read_text()
     # ensure boilerplate was not recreated
     for bpl in boilerplate:
         assert not bpl.exists()


### PR DESCRIPTION
Fixes: https://github.com/salt-extensions/salt-extension-copier/issues/196

Also, fixes nox test venv installation of Salt when `uv` is unavailable (as it is now in CI, since uv 0.7.0 broke the nox integration by replacing the `uv version` command and the latest nox release, which fixes this, needs to be excluded since it has an incorrect lower bound requirement for `attrs`, which is an issue since Salt's pinned version is lower than the correct lower bound).

Minor changes:

* The Copier 9.7+ behavior regarding ContextHooks allows to skip loading data files in copier.yml
* Remove workaround for weird `_skip_if_exists` behavior
* Hotfixes nox 2025.5.1 breakage