### PR TITLE
CI fixes and misc stuff

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,10 @@
     customManagers: [
         {
             customType: "regex",
-            fileMatch: ["^data/versions.yaml$", "^\\.pre-commit-config\\.yaml$"],
+            managerFilePatterns: [
+                "/^data/versions.yaml$/",
+                "/^\\.pre-commit-config\\.yaml$/"
+            ],
             matchStrings: [
                 "# renovate: datasource=(?<datasource>git.*-tags) depName=(?<depName>[^\\s]+?)(?: depType=(?<depType>[^\\s]+?))?(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_/-]+?\\s*:\\s*[\"']?(?<currentDigest>[a-f0-9]+?)\\s+#\\s*(?<currentValue>v?[0-9.]+?)[\"']?\\s",
                 "# renovate: datasource=(?<datasource>docker) depName=(?<depName>[^\\s]+?)(?: depType=(?<depType>[^\\s]+?))?(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_/-]+?\\s*:\\s*[\"']?([^:\\s]+:)?(?<currentValue>.+?)@(?<currentDigest>sha256:[a-f0-9]+?)[\"']?\\s",
@@ -13,21 +16,21 @@
         },
         {
             customType: "regex",
-            fileMatch: ["^\\.pre-commit-config\\.yaml$"],
+            managerFilePatterns: ["/^\\.pre-commit-config\\.yaml$/"],
             matchStrings: [
                 "# renovate: datasource=(?<datasource>pypi) depName=(?<depName>[^\\s]+?)(?: depType=(?<depType>[^\\s]+?))?(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+-\\s*[\"']?[A-Za-z0-9_\\-\\.]+?==(?<currentValue>.+?)[\"']?\\s",
             ],
         },
         {
             customType: "regex",
-            fileMatch: ["^noxfile\\.py$"],
+            managerFilePatterns: ["/^noxfile\\.py$/"],
             matchStrings: [
                 "# renovate: datasource=(?<datasource>pypi)(?: depType=(?<depType>[^\\s]+?))?(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[^\\n]*\"(?<depName>[A-Za-z0-9_\\-\\.]+?)==(?<currentValue>.+?)\",?\\s",
             ],
         },
         {
             customType: "regex",
-            fileMatch: ["^data/salt_latest_point.yaml$"],
+            managerFilePatterns: ["/^data/salt_latest_point.yaml$/"],
             matchStrings: [
                 "(?<major>\\d+): (?<minor>\\d+)\\s",
             ],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,8 +126,10 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pytest": ("https://docs.pytest.org/en/stable", None),
     "salt": ("https://docs.saltproject.io/en/latest", None),
-    "saltfactories": ("https://pytest-salt-factories.readthedocs.io/en/latest", None),
+    # FIXME: Reenable once the docs are back online
+    # "saltfactories": ("https://pytest-salt-factories.readthedocs.io/en/latest", None),
 }
+intersphinx_disabled_reftypes = ["saltfactories:*"]
 # <---- Intersphinx Config -----------------------------------------------------------------------------------------
 
 # Towncrier draft config

--- a/docs/topics/installation.md
+++ b/docs/topics/installation.md
@@ -10,7 +10,7 @@ It’s recommended to install Copier globally using either [uv][uv-docs] or [pip
 
 
 ```bash
-uv tool install --python 3.10 --with copier-templates-extensions 'copier>=9.6'
+uv tool install --python 3.10 --with copier-template-extensions 'copier>=9.6'
 ```
 :::
 
@@ -18,7 +18,7 @@ uv tool install --python 3.10 --with copier-templates-extensions 'copier>=9.6'
 
 ```bash
 pipx install 'copier>=9.6' && \
- pipx inject copier copier-templates-extensions
+ pipx inject copier copier-template-extensions
 ```
 :::
 
@@ -27,7 +27,7 @@ pipx install 'copier>=9.6' && \
 Alternatively, you can install Copier with `pip`, preferably inside a virtual environment:
 
 ```bash
-python -m pip install 'copier>=9.6' copier-templates-extensions
+python -m pip install 'copier>=9.6' copier-template-extensions
 ```
 :::
 
@@ -36,11 +36,11 @@ The `copier` virtual environment should be based on the Python version (MAJOR.MI
 :::
 
 :::{important}
-This template includes custom Jinja extensions, so ensure that [copier-templates-extensions][copier-templates-extensions] is installed in the same environment as `copier`. The example commands above handle this.
+This template includes custom Jinja extensions, so ensure that [copier-template-extensions][copier-template-extensions] is installed in the same environment as `copier`. The example commands above handle this.
 :::
 
 [copier-docs]: https://copier.readthedocs.io/en/stable/
 [copier-multiselect-pr]: https://github.com/copier-org/copier/pull/1386
-[copier-templates-extensions]: https://github.com/copier-org/copier-templates-extensions
+[copier-template-extensions]: https://github.com/copier-org/copier-template-extensions
 [pipx-docs]: https://pipx.pypa.io/stable/
 [uv-docs]: https://docs.astral.sh/uv/

--- a/noxfile.py
+++ b/noxfile.py
@@ -63,7 +63,7 @@ DOCSAUTO_REQUIREMENTS = ("sphinx-autobuild",)
 
 TESTS_REQUIREMENTS = (
     "copier>=9.6",
-    "copier-templates-extensions",
+    "copier-template-extensions",
     "plumbum",
     "pytest",
     "pytest-copie>=0.2.2",

--- a/tasks/migrations.py
+++ b/tasks/migrations.py
@@ -43,6 +43,15 @@ def ensure_minimum_python_requires(answers):
     return answers
 
 
+@var_migration("0.9.1", "max_salt_version")
+def migrate_091_max_salt_version_3008(val):
+    """
+    Raise max_salt_version to 3008 if it was 3007 previously
+    """
+    if Version(str(val)).major == 3007:
+        return "3008"
+
+
 @var_migration("0.4.5", "max_salt_version")
 def migrate_045_max_salt_version(val):
     """

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -78,6 +78,7 @@ def test_project_init_works(copie, answers, capfd):
 
 @pytest.mark.parametrize("skip_init_migrate", (False,), indirect=True)
 @pytest.mark.parametrize("project", ("0.7.2",), indirect=True)
+@pytest.mark.parametrize("max_salt_version", ("3007",), indirect=True)
 def test_project_migration_works(copie, project, project_venv, request, capfd):
     """
     Ensure the generated project can be updated as expected


### PR DESCRIPTION
* Fixes `copier update` test (`max_salt_version` was read from repo, which knows about 3008, but the old template version does not)
* Automatically adjusts `max_salt_version` on update
* Makes doc build work again (`pytest-salt-factories` docs are gone)
* Updates Renovate config
* Fixes `copier-templates-extensions` -> `copier-template-extensions` since it has been renamed