### PR TITLE
Recommend Py 3.14, other Python version adjustments

### DIFF
--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Set up Python 3.12 For Nox
+      - name: Set up Python For Nox
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.12"
+          python-version: '3.14'
 
       - name: Install Nox
         run: |

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -14,7 +14,7 @@ jobs:
     name: Pre-Commit
     runs-on: ubuntu-24.04
     container:
-      image: docker.io/library/python:3.10.20-slim-bookworm@sha256:89cef4d55961e885def21b86e34e102e65b7eab8cd281e806a66ff1709c9a455
+      image: docker.io/library/python:3.10.20-slim-trixie@sha256:5f9928ea39771e8ddf4fb9a96ab24f65f087793635614405a1dc9384f040852e
 
     steps:
       - name: Install System Deps

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Install Nox
         run: |
@@ -81,10 +81,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Install Nox
         run: |
@@ -146,10 +146,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Install Nox
         run: |

--- a/changelog/+3007unsupported.changed.md
+++ b/changelog/+3007unsupported.changed.md
@@ -1,0 +1,1 @@
+Marked Salt 3007 as no longer supported, meaning it is no longer tested against if `min_salt_version` == 3006. `min_salt_version` == 3007 is automatically migrated to 3008.

--- a/changelog/+3008.added.md
+++ b/changelog/+3008.added.md
@@ -1,0 +1,1 @@
+Added Salt 3008

--- a/changelog/+precommitwfpy.fixed.md
+++ b/changelog/+precommitwfpy.fixed.md
@@ -1,0 +1,1 @@
+Fixed pre-commit workflow Python version if `python_requires` is higher than 3.10. pre-commit should always run with the minimally supported Python of the project, while it was previously hardcoded to 3.10.

--- a/changelog/+venvpy.changed.md
+++ b/changelog/+venvpy.changed.md
@@ -1,0 +1,1 @@
+Switched recommended venv Python version from 3.10 to 3.14

--- a/data/salt_python_support.yaml
+++ b/data/salt_python_support.yaml
@@ -15,16 +15,18 @@
     - 10
 3006:
   lts: true
+  supported: true
   min:
     - 3
     - 10
   max:
     - 3
-    - 10
+    - 14
   onedir:
     - 3
     - 10
 3007:
+  supported: false
   min:
     - 3
     - 10
@@ -36,6 +38,7 @@
     - 10
 3008:
   lts: true
+  supported: true
   min:
     - 3
     - 10

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -105,9 +105,20 @@ windows: '2025'
 #  GitHub Actions containers
 ###########################################################
 
-# renovate: datasource=docker depName=python-pre-commit-action packageName=docker.io/library/python depType=container
-python_container: '3.10.20-slim-bookworm@sha256:b1f549b1c3da651d93802122ebcb0c3177702a6d549676236c859ad19e79e9da'
+# renovate: datasource=docker depName=python-pre-commit-action-310 packageName=docker.io/library/python depType=container
+python_container_310: '3.10.20-slim-trixie@sha256:5f9928ea39771e8ddf4fb9a96ab24f65f087793635614405a1dc9384f040852e'
 
+# renovate: datasource=docker depName=python-pre-commit-action-311 packageName=docker.io/library/python depType=container
+python_container_311: '3.11.15-slim-trixie@sha256:b27df5841f3355e9473f9a516d38a6783b6c8dfeacaf2d14a240f443b368ddb6'
+
+# renovate: datasource=docker depName=python-pre-commit-action-312 packageName=docker.io/library/python depType=container
+python_container_312: '3.12.13-slim-trixie@sha256:423ed6ab25b1921a477529254bfeeabf5855151dc2c3141699a1bfc852199fbf'
+
+# renovate: datasource=docker depName=python-pre-commit-action-313 packageName=docker.io/library/python depType=container
+python_container_313: '3.13.14-slim-trixie@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280'
+
+# renovate: datasource=docker depName=python-pre-commit-action-314 packageName=docker.io/library/python depType=container
+python_container_314: '3.14.6-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1'
 
 ###########################################################
 #  Misc

--- a/docs/topics/creation.md
+++ b/docs/topics/creation.md
@@ -49,7 +49,7 @@ This process is automated completely in the following cases:
 * For all developers: If you have a working `direnv` installation, you can copy the included `.envrc.example` to `.envrc` and allow it to run. This takes care of the [dev env setup](dev-setup-target) and [pre-commit hook installation](hook-install-target) as well as activating the virtual environment. Without `direnv`, you can also run `make dev` to create/update the development environment. Remember to activate it via `source .venv/bin/activate` afterwards.
 
 :::{important}
-The automation either requires [`uv`](https://github.com/astral-sh/uv) or the Python version (MAJOR.MINOR) [listed here](https://github.com/saltstack/salt/blob/master/cicd/shared-gh-workflows-context.yml) to be available on your system, at the time of writing Python 3.10.
+The automation either requires [`uv`](https://github.com/astral-sh/uv) or the Python version (MAJOR.MINOR) [listed here](https://github.com/saltstack/salt/blob/master/cicd/shared-gh-workflows-context.yml) to be available on your system, at the time of writing Python 3.14.
 :::
 
 :::{hint}
@@ -75,11 +75,11 @@ Some automations assume your default branch is `main`. Ensure this is the case.
 (dev-setup-target)=
 ### Initialize the Python virtual environment
 :::{important}
-To create the virtualenv, it is recommended to use the same Python version (MAJOR.MINOR) as the one [listed here](https://github.com/saltstack/salt/blob/master/cicd/shared-gh-workflows-context.yml), at the time of writing Python 3.10.
+To create the virtualenv, it is recommended to use the same Python version (MAJOR.MINOR) as the one [listed here](https://github.com/saltstack/salt/blob/master/cicd/shared-gh-workflows-context.yml), at the time of writing Python 3.14.
 :::
 
 ```bash
-python3.10 -m venv .venv
+python3.14 -m venv .venv
 source .venv/bin/activate
 python -m pip install -e '.[tests,dev,docs]'
 ```

--- a/docs/topics/installation.md
+++ b/docs/topics/installation.md
@@ -10,7 +10,7 @@ It’s recommended to install Copier globally using either [uv][uv-docs] or [pip
 
 
 ```bash
-uv tool install --python 3.10 --with copier-template-extensions 'copier>=9.6'
+uv tool install --python 3.14 --with copier-template-extensions 'copier>=9.6'
 ```
 :::
 
@@ -32,7 +32,7 @@ python -m pip install 'copier>=9.6' copier-template-extensions
 :::
 
 :::{note}
-The `copier` virtual environment should be based on the Python version (MAJOR.MINOR) [listed here](https://github.com/saltstack/salt/blob/master/cicd/shared-gh-workflows-context.yml), at the time of writing Python 3.10. Other versions - especially higher ones - should work, but the template's CI tests only verify the mentioned version.
+The `copier` virtual environment should be based on the Python version (MAJOR.MINOR) [listed here](https://github.com/saltstack/salt/blob/master/cicd/shared-gh-workflows-context.yml), at the time of writing Python 3.14. Other versions - especially higher ones - should work, but the template's CI tests only verify the mentioned version.
 :::
 
 :::{important}

--- a/jinja_extensions/saltext.py
+++ b/jinja_extensions/saltext.py
@@ -39,6 +39,7 @@ class SaltExt(ContextHook):
                 "max": tuple(defs["max"]),
                 "onedir": tuple(defs.get("onedir", defs["max"])),
                 "lts": defs.get("lts", False),
+                "supported": defs.get("supported"),
             }
             for version, defs in sps.items()
         }

--- a/project/.pre-commit-hooks/make-autodocs.py.j2
+++ b/project/.pre-commit-hooks/make-autodocs.py.j2
@@ -17,8 +17,8 @@ def _find_virtualname(path):
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == "__virtualname__":
-                    if isinstance(node.value, ast.Str):
-                        virtualname = node.value.s
+                    if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                        virtualname = node.value.value
                         break
             else:
                 continue

--- a/project/Makefile
+++ b/project/Makefile
@@ -43,12 +43,12 @@ changelog: dev ## Render changelog. Requires VERSION parameter.
 .PHONY: docs
 docs: dev ## Build docs
 	@source .venv/bin/activate; \
-	  nox -e docs --extra-pythons=3.10 --python=3.10
+	  nox -e docs --extra-pythons=3.14 --python=3.14
 
 .PHONY: docs-dev
 docs-dev: dev ## Build docs, serve them and refresh on changes
 	@source .venv/bin/activate; \
-	  nox -e docs-dev --extra-pythons=3.10 --python=3.10
+	  nox -e docs-dev --extra-pythons=3.14 --python=3.14
 
 ## Tests
 

--- a/project/tools/helpers/cmd.py
+++ b/project/tools/helpers/cmd.py
@@ -122,6 +122,15 @@ class Local:
         """
         return self._env.get("PATH", "").split(os.pathsep)
 
+    def which(self, cmd):
+        """
+        Find `cmd` in $PATH.
+        """
+        res = shutil.which(cmd)
+        if not res:
+            raise CommandNotFound(cmd)
+        return Path(res)
+
     @contextmanager
     def cwd(self, path):
         """

--- a/project/tools/helpers/cmd.py
+++ b/project/tools/helpers/cmd.py
@@ -8,12 +8,10 @@ import platform
 import shlex
 import shutil
 import subprocess
-import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
-from typing import Union
 
 
 class CommandNotFound(RuntimeError):

--- a/project/tools/helpers/venv.py
+++ b/project/tools/helpers/venv.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from shutil import rmtree
 
 from . import prompt
 from .cmd import CommandNotFound
@@ -8,7 +9,7 @@ from .copier import discover_project_name
 
 # Should follow the version used for relenv packages, see
 # https://github.com/saltstack/salt/blob/master/cicd/shared-gh-workflows-context.yml
-RECOMMENDED_PYVER = "3.10"
+RECOMMENDED_PYVER = "3.14"
 # For discovery of existing virtual environment, descending priority.
 VENV_DIRS = (
     ".venv",
@@ -18,10 +19,11 @@ VENV_DIRS = (
 )
 
 
-try:
-    uv = local["uv"]
-except CommandNotFound:
-    uv = None
+def discover_uv():
+    try:
+        return local["uv"]
+    except CommandNotFound:
+        pass
 
 
 def is_venv(path):
@@ -38,12 +40,20 @@ def discover_venv(project_root="."):
     raise RuntimeError(f"No venv found in {base}")
 
 
+def venv_pyver(venv):
+    for line in (venv / "pyvenv.cfg").read_text().splitlines():
+        if line.startswith("version =") or line.startswith("version_info ="):
+            pyver = line.split(" = ")[1].split(".")
+            return f"{pyver[0]}.{pyver[1]}"
+
+
 def create_venv(project_root=".", directory=None):
     base = Path(project_root).resolve()
     venv = (base / (directory or VENV_DIRS[0])).resolve()
     if is_venv(venv):
         raise RuntimeError(f"Venv at {venv} already exists")
     prompt.status(f"Creating virtual environment at {venv}")
+    uv = discover_uv()
     if uv is not None:
         prompt.status("Found `uv`. Creating venv")
         uv(
@@ -74,6 +84,15 @@ def ensure_project_venv(project_root=".", reinstall=True, install_extras=False):
     try:
         venv = discover_venv(project_root)
         prompt.status(f"Found existing virtual environment at {venv}")
+
+        pyver = venv_pyver(venv)
+        if pyver != RECOMMENDED_PYVER:
+            prompt.status(
+                f"Existing venv has Python {pyver}, but recommended is {RECOMMENDED_PYVER}. Recreating."
+            )
+            rmtree(venv)
+            raise RuntimeError("Existing venv does not use recommended Python version")
+
         exists = True
     except RuntimeError:
         venv = create_venv(project_root)
@@ -84,6 +103,7 @@ def ensure_project_venv(project_root=".", reinstall=True, install_extras=False):
         extras.append("dev_extra")
     prompt.status(("Reinstalling" if exists else "Installing") + " project and dependencies")
     with local.venv(venv):
+        uv = discover_uv()
         if uv is not None:
             uv("pip", "install", "-e", f".[{','.join(extras)}]")
         else:

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/pre-commit-action.yml.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/pre-commit-action.yml.j2
@@ -19,7 +19,7 @@ jobs:
 {%- endraw %}
     runs-on: ubuntu-{{ versions["ubuntu"] }}
     container:
-      image: 'docker.io/library/python:{{ versions["python_container"] }}'
+      image: 'docker.io/library/python:{{ versions["python_container_" ~ (python_requires | join(""))] }}'
 {%- raw %}
 
     steps:

--- a/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/test-action.yml.j2
+++ b/project/{% if 'github.com' in source_url %}.github{% endif %}/workflows/test-action.yml.j2
@@ -18,7 +18,14 @@ jobs:
       fail-fast: false
 {%-   endraw %}
 {%-   set test_matrix = [] %}
+{%-   set supported_seen = [] %}
+{%-   set lowest_pyver_included = [] %}
 {%-   for sver in range(salt_version_major, max_salt_version_major + 1) %}
+{%-     if supported_seen and not salt_python_support[sver]["supported"] %}
+{%-       continue %}
+{%-     elif salt_python_support[sver]["supported"] %}
+{%-       do supported_seen.append(true) %}
+{%-     endif %}
 
 {%-     if sver == max_salt_version_major %}
 {%-       set sver_minor = (salt_latest_point[sver], max_salt_version_minor) | min %}
@@ -27,15 +34,19 @@ jobs:
 {%-     endif %}
 
 {%-     if salt_python_support[sver]["lts"] %}
-{%-       set min_pyver = (python_requires[1], salt_python_support[sver]["min"][1]) | max %}
+{%-       set test_py_versions = [
+            (python_requires[1], salt_python_support[sver]["onedir"][1]) | max,
+            salt_python_support[sver]["max"][1]
+          ] %}
 {%-     else %}
-{%-       set min_pyver = (python_requires[1], salt_python_support[sver]["onedir"][1]) | max %}
+{%-       set test_py_versions = [(python_requires[1], salt_python_support[sver]["onedir"][1]) | max] %}
+{%-     endif %}
+{%-     if not lowest_pyver_included %}
+{%-       do test_py_versions.append((python_requires[1], salt_python_support[sver]["min"][1]) | max) %}
+{%-       do lowest_pyver_included.append(true) %}
 {%-     endif %}
 
-{%-     for pyver in range(
-          min_pyver,
-          (max_python_minor, salt_python_support[sver]["max"][1]) | min + 1
-        ) %}
+{%-     for pyver in test_py_versions | unique | sort  %}
 {%-       do test_matrix.append(("{}.{}".format(sver, sver_minor), "3.{}".format(pyver))) %}
 {%-     endfor %}
 {%-   endfor %}
@@ -145,7 +156,13 @@ jobs:
       fail-fast: false
 {%-   endraw %}
 {%-   set test_matrix = [] %}
+{%-   set supported_seen = [] %}
 {%-   for sver in range(salt_version_major, max_salt_version_major + 1) %}
+{%-     if supported_seen and not salt_python_support[sver]["supported"] %}
+{%-       continue %}
+{%-     elif salt_python_support[sver]["supported"] %}
+{%-       do supported_seen.append(true) %}
+{%-     endif %}
 
 {%-     if sver == max_salt_version_major %}
 {%-       set sver_minor = (salt_latest_point[sver], max_salt_version_minor) | min %}
@@ -153,7 +170,7 @@ jobs:
 {%-       set sver_minor = salt_latest_point[sver] %}
 {%-     endif %}
 
-{%-     set pyver = (python_requires[1], salt_python_support[sver]["min"][1]) | max %}
+{%-     set pyver = (python_requires[1], salt_python_support[sver]["onedir"][1]) | max %}
 {%-     do test_matrix.append(("{}.{}".format(sver, sver_minor), "3.{}".format(pyver))) %}
 {%-   endfor %}
       max-parallel: {{ (test_matrix | length, 3) | min }}
@@ -270,7 +287,13 @@ jobs:
 
 {%-   set test_matrix = [] %}
 {%-   set macos_pyver = [] %}
+{%-   set supported_seen = [] %}
 {%-   for sver in range(salt_version_major, max_salt_version_major + 1) %}
+{%-     if supported_seen and not salt_python_support[sver]["supported"] %}
+{%-       continue %}
+{%-     elif salt_python_support[sver]["supported"] %}
+{%-       do supported_seen.append(true) %}
+{%-     endif %}
 
 {%-     if sver == max_salt_version_major %}
 {%-       set sver_minor = (salt_latest_point[sver], max_salt_version_minor) | min %}
@@ -278,14 +301,7 @@ jobs:
 {%-       set sver_minor = salt_latest_point[sver] %}
 {%-     endif %}
 
-{%-     set pyver = (
-                      (python_requires[1], salt_python_support[sver]["min"][1]) | max + 1,
-                      salt_python_support[sver]["max"][1]
-                    ) | min %}
-{%-     if pyver in macos_pyver %}
-{%-       set pyver = (pyver + (sver - salt_version_major), salt_python_support[sver]["max"][1]) | min %}
-{%-     endif %}
-{%-     do macos_pyver.append(pyver) %}
+{%-     set pyver = (python_requires[1], salt_python_support[sver]["onedir"][1]) | max %}
 {%-     do test_matrix.append(("{}.{}".format(sver, sver_minor), "3.{}".format(pyver))) %}
 {%-   endfor %}
       max-parallel: {{ (test_matrix | length, 3) | min }}

--- a/tasks/task_helpers/migrate.py
+++ b/tasks/task_helpers/migrate.py
@@ -115,7 +115,7 @@ def migration(trigger, stage="after", desc=None, after=None):
                 desc = func.__name__.replace("_", " ")
             elif not desc:
                 desc = None
-            func = Migration(func, desc=desc)
+            func = Migration(func, desc=desc, after=after)
         global MIGRATIONS
         MIGRATIONS.append((trigger_version, func))
         return func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,14 +112,18 @@ def project(answers, request, copie, skip_init_migrate):  # pylint: disable=unus
 
 
 @pytest.fixture
-def project_committed(project):
+def git():
+    return local["git"][
+        "-c", "commit.gpgsign=false", "-c", "user.name=foobar", "-c", "user.email=foo@b.ar"
+    ]
+
+
+@pytest.fixture
+def project_committed(project, git):
     with local.cwd(project.project_dir):
-        git = local["git"][
-            "-c", "commit.gpgsign=false", "-c", "user.name=foobar", "-c", "user.email=foo@b.ar"
-        ]
         git("init")
         git("add", ".")
-        git("commit", "-m", "initial commit")
+        git("commit", "-m", "initial commit", "--no-verify")
     return project
 
 

--- a/tests/helpers/venv.py
+++ b/tests/helpers/venv.py
@@ -64,6 +64,11 @@ class VirtualEnv:
     def __exit__(self, *args):
         shutil.rmtree(str(self.venv_dir), ignore_errors=True)
 
+    @property
+    def pyver(self):
+        ver = self.run(str(self.venv_python), "--version").stdout.split(" ")[1].split(".")
+        return f"{ver[0]}.{ver[1]}"
+
     def install(self, *args, **kwargs):
         return self.run_module("pip", "install", *args, **kwargs)
 

--- a/tests/helpers/venv.py
+++ b/tests/helpers/venv.py
@@ -115,26 +115,30 @@ class VirtualEnv:
         virtualenv because it will fail otherwise
         """
         try:
-            if sys.platform.startswith("win"):
-                return os.path.join(sys.real_prefix, os.path.basename(sys.executable))
-            python_binary_names = [
-                "python{}.{}".format(*sys.version_info),
-                "python{}".format(*sys.version_info),
-                "python",
-            ]
-            for binary_name in python_binary_names:
-                python = os.path.join(sys.real_prefix, "bin", binary_name)
-                if os.path.exists(python):
-                    break
-            else:
-                raise AssertionError(
-                    "Couldn't find a python binary name under '{}' matching: {}".format(
-                        os.path.join(sys.real_prefix, "bin"), python_binary_names
-                    )
-                )
-            return python
+            base_prefix = sys.base_prefix
         except AttributeError:
-            return sys.executable
+            try:
+                base_prefix = sys.real_prefix
+            except AttributeError:
+                return sys.executable
+        if sys.platform.startswith("win"):
+            return os.path.join(base_prefix, os.path.basename(sys.executable))
+        python_binary_names = [
+            "python{}.{}".format(*sys.version_info),
+            "python{}".format(*sys.version_info),
+            "python",
+        ]
+        for binary_name in python_binary_names:
+            python = os.path.join(base_prefix, "bin", binary_name)
+            if os.path.exists(python):
+                break
+        else:
+            raise AssertionError(
+                "Couldn't find a python binary name under '{}' matching: {}".format(
+                    os.path.join(base_prefix, "bin"), python_binary_names
+                )
+            )
+        return python
 
     def run_code(self, code_string, python=None, **kwargs):
         if code_string.startswith("\n"):
@@ -194,4 +198,4 @@ class ProjectVenv(VirtualEnv):
                 local["git"]("init", "--initial-branch=main")
         if not (self.venv_dir / "pyvenv.cfg").exists():
             super()._create_virtualenv()
-        self.install(f"{self.project_dir}[dev,docs,tests]")
+            self.install(f"{self.project_dir}[dev,docs,tests]")

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -6,7 +6,6 @@ from plumbum import local
 
 from tests.helpers.pre_commit import check_pre_commit_rerun
 from tests.helpers.pre_commit import parse_pre_commit
-from tests.helpers.venv import ProjectVenv
 
 pytestmark = [
     pytest.mark.usefixtures(
@@ -115,6 +114,8 @@ def test_project_migration_works(copie, project, project_venv, request, capfd):
     project_venv.install("nox==2023.4.22")
     _check_version(True)
     assert project_venv.pyver == "3.10"
+    # Windows has issues here. For some reason, pre-commit runs make-autodocs.py
+    # with the wrong Python version there. This fixture skips pre-commit.
     request.getfixturevalue("project_committed")
     res = copie.update(project)
     _assert_worked(res)
@@ -166,14 +167,14 @@ def _commit_with_pre_commit(venv, max_retry=3, message="initial commit"):
         raise AssertionError(msg)
 
 
-def test_first_commit_works(project):
+def test_first_commit_works(project, project_venv):
     """
     Ensure the generated project can be committed after generation
     with pre-commit hooks active.
     It should take at most three tries.
     """
-    with ProjectVenv(project.project_dir) as venv, local.cwd(project.project_dir):
-        _commit_with_pre_commit(venv, max_retry=3)
+    with local.cwd(project.project_dir):
+        _commit_with_pre_commit(project_venv, max_retry=3)
 
 
 @pytest.mark.parametrize("no_saltext_namespace", (False, True), indirect=True)
@@ -196,10 +197,10 @@ def test_testsuite_works(project, project_venv):
 
 @pytest.mark.parametrize("no_saltext_namespace", (False, True), indirect=True)
 def test_docs_build_works(project, project_venv):
-    with ProjectVenv(project.project_dir) as venv, local.cwd(project.project_dir):
+    with local.cwd(project.project_dir):
         for check in (False, True):
-            venv.run(
-                venv.venv_python,
+            project_venv.run(
+                project_venv.venv_python,
                 str(project.project_dir / ".pre-commit-hooks" / "make-autodocs.py"),
                 check=check,
             )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -114,6 +114,7 @@ def test_project_migration_works(copie, project, project_venv, request, capfd):
     # downgrade nox below minimum version
     project_venv.install("nox==2023.4.22")
     _check_version(True)
+    assert project_venv.pyver == "3.10"
     request.getfixturevalue("project_committed")
     res = copie.update(project)
     _assert_worked(res)
@@ -127,6 +128,8 @@ def test_project_migration_works(copie, project, project_venv, request, capfd):
         assert not bpl.exists()
     # ensure the project was reinstalled
     _check_version(False)
+    # ensure the venv was recreated with the correct Python
+    assert project_venv.pyver == "3.14"
 
 
 @pytest.mark.usefixtures("project_committed")


### PR DESCRIPTION
* Since all supported releases (the 3006 and 3008 lines) support Python 3.14 and 3008 uses 3.14 in its Onedir, switch the recommended venv Python to 3.14.
* Update the 3.10 pre-commit Python container from bookworm to trixie
* Add pre-commit Python containers for 3.11, 3.12, 3.13 and 3.14
* Make the pre-commit workflow use the real minimally supported Python version, not 3.10 always
* Adjust how we generate the test matrix to account for the 3007 line being no longer supported and more Python versions being in the supported range. Note: We already migrate min_salt_version == 3007 to 3008.